### PR TITLE
fix: update link leading to date object information

### DIFF
--- a/src/core-js-dates-tasks.js
+++ b/src/core-js-dates-tasks.js
@@ -2,7 +2,7 @@
  *                                                                                             *
  * Please read the following tutorial before implementing tasks:                               *
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date       *
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Numbers_and_dates#date_object *
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Representing_dates_times      *
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl       *
  *                                                                                             *
  ********************************************************************************************* */


### PR DESCRIPTION
#### Title of Pull Request

Update link leading to date object information

#### 🤔 This is a ...

- [ ] 🌟 New task
- [ ] 🌐 New module
- [ ] ⚙️ Update to an existing task
- [ ] 🔧 Update to an existing module
- [ ] 🔗 Update or addition of external resources or links
- [x] 🐛 Fix in a task or related content
- [ ] 🛠 Fix in a module or related content
- [ ] ✏️ Fixed a typo or grammatical error
- [ ] 🔗 Fixed a broken link
- [ ] ❓ Other (specify: **\*\*\*\***\_\_\_\_**\*\*\*\***)

#### Description

- **Brief Overview:**
 The second link in the tutorial section of the code comments leads to a non-existent page. This link was originally intended to provide guidance on working with JavaScript dates but now leads to Numbers and strings.

- **Implementation Approach:**
 Old [link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Numbers_and_dates#date_object) has been updated to the current [page](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Representing_dates_times) dedicated to the Date Object. 

#### Additional Information

- **Screenshots/Links:**
  <!-- 📸 Include any relevant screenshots or links to documentation or discussions -->
- [ ] Related Issues:
<!-- 🔗 Mention any related issues or pull requests if applicable -->

#### Checklist

- [ ] ✅ I have performed a self-review of my own code.
- [ ] 📝 I have commented my code, particularly in hard-to-understand areas.
- [ ] 🔧 I have made corresponding changes to the documentation (if applicable).
- [ ] 🚫 My changes generate no new warnings or errors.

