### PR TITLE
Update configs and deps

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+extensions

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   env: {
     commonjs: true,
-    es6: true,
+    es2024: true,
     node: true,
     mocha: true,
   },
@@ -12,17 +12,7 @@ module.exports = {
     SharedArrayBuffer: 'readonly',
   },
   parserOptions: {
-    ecmaVersion: 2022,
+    ecmaVersion: 2024,
   },
-  rules: {
-    'prettier/prettier': [
-      'error',
-      {
-        endOfLine: 'auto',
-      },
-    ],
-  },
-  plugins: ['prettier'],
-  ignorePatterns: ['extensions/*'],
   noInlineConfig: true,
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-/extensions/*

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "tabWidth": 2,
   "semi": true,
   "singleQuote": true,
-  "printWidth": 80
+  "printWidth": 80,
+  "endOfLine": "auto"
 }

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The task is to implement functions on different Core JS topics. This module requ
 
 ## Notes
 
-- We recommend you to use nodejs of version 16 or lower. If you using any of features that does not supported by node `v16`, score won't be submitted.
-- Installing nodejs `v16` is optional, you can run jobs using your version and not use methods that are not in nodejs `v16`.
+- We recommend you to use nodejs of version 22 or lower. If you using any of features that does not supported by node `v22`, score won't be submitted.
+- Installing nodejs `v22` is optional, you can run jobs using your version and not use methods that are not in nodejs `v22`.
 - Please be sure that each of your test in limit of 30sec.
 - You will get 0 (zero) if you have any eslint's errors or warnings.
 

--- a/package.json
+++ b/package.json
@@ -15,13 +15,12 @@
   "author": "mikaleinik",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^8.53.0",
+    "eslint": "^8.57.1",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-config-prettier": "^9.0.0",
-    "eslint-plugin-import": "^2.29.0",
-    "eslint-plugin-prettier": "^5.0.1",
-    "mocha": "^10.2.0",
-    "prettier": "^3.0.3"
+    "eslint-config-prettier": "^10.1.1",
+    "eslint-plugin-prettier": "^5.2.3",
+    "mocha": "^10.8.2",
+    "prettier": "^3.5.3"
   },
   "bugs": {
     "url": "https://github.com/rolling-scopes-school/core-js-dates/issues"


### PR DESCRIPTION
- обновил ecmascript глобалы и парсер (eslintrc)
- переместил правило для crlf/lf туда, где ему логичнее быть (eslintrc -> prettierrc)
- добавил в игнор папку с утилитами для тестов (eslintignore)
- обновил минорные версии зависимостей у 4 пакетов и мажорную у 1 пакета
- прогнал `npm run lint` и `npm run test` с пустыми солюшнами и с солюшнами рандомного студента, добавив в некоторые решения использование es2024 фич